### PR TITLE
Adding the ability to have a dynamic postfix with the title

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -616,6 +616,14 @@ Publishing configuration
 
        confluence_publish_postfix = '-postfix'
 
+    Dynamic postfixes are an option as well to allow for pages with the same title
+    to be pushed to the same space without needing to add a manual index to the title
+    with the use of '&unique_hash' as the postfix value. This hash value is calculated
+    using the relative path to the file and specified
+    confluence_publish_root/confluence_parent_page.
+
+    Note, pages with the same title must have different parent pages.
+
     By default, no postfix is used. See also:
 
     - |confluence_ignore_titlefix_on_index|_

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -281,7 +281,9 @@ class ConfluenceBuilder(Builder):
                     doctitle = ('.'.join(map(str, secnumbers[''])) +
                         self.secnumber_suffix + doctitle)
 
-                self.state.register_title(docname, doctitle, self.config)
+                self.state.register_title(
+                    docname, doctitle, self.config, doc_source_path=doctree.attributes['source'],
+                    src_dir=self.env.srcdir)
 
                 # only publish documents that sphinx asked to prepare
                 if docname in docnames:

--- a/tests/unit-tests/datasets/titlehash/index.rst
+++ b/tests/unit-tests/datasets/titlehash/index.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+Index page
+==========
+
+.. toctree::
+    readme
+    submodule/readme

--- a/tests/unit-tests/datasets/titlehash/readme.rst
+++ b/tests/unit-tests/datasets/titlehash/readme.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+readme
+======
+
+Top level readme

--- a/tests/unit-tests/datasets/titlehash/submodule/readme.rst
+++ b/tests/unit-tests/datasets/titlehash/submodule/readme.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+readme
+======
+
+Inner readme

--- a/tests/unit-tests/test_config_titlehash.py
+++ b/tests/unit-tests/test_config_titlehash.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+import os
+
+from sphinx.errors import SphinxWarning
+
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+from tests.lib import parse
+
+
+class TestConfluenceConfigTitleHash(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceConfigTitleHash, cls).setUpClass()
+
+        cls.config['root_doc'] = 'index'
+        cls.dataset = os.path.join(cls.datasets, 'titlehash')
+
+    @setup_builder('confluence')
+    def test_no_parent_or_root_page_configured(self):
+        config = dict(self.config)
+        config['confluence_publish_postfix'] = '&unique_hash'
+
+        out_dir = self.build(self.dataset, config=config)
+        with parse('index', out_dir) as data:
+            page_refs = data.find_all('ri:page')
+            assert len(page_refs) == 2
+            self.assertEqual(page_refs[0]['ri:content-title'], 'readme -4fca3e8b2a')
+            self.assertEqual(page_refs[1]['ri:content-title'], 'readme -3d2e5ea88a')
+
+    @setup_builder('confluence')
+    def test_parent_page_configured(self):
+        config = dict(self.config)
+        config['confluence_publish_postfix'] = '&unique_hash'
+        config['confluence_parent_page'] = 'parent page'
+
+        out_dir = self.build(self.dataset, config=config)
+        with parse('index', out_dir) as data:
+            page_refs = data.find_all('ri:page')
+            assert len(page_refs) == 2
+            self.assertEqual(page_refs[0]['ri:content-title'], 'readme -5605474e81')
+            self.assertEqual(page_refs[1]['ri:content-title'], 'readme -d64d7f0c67')
+
+    @setup_builder('confluence')
+    def test_publish_root_configured(self):
+        config = dict(self.config)
+        config['confluence_publish_postfix'] = '&unique_hash'
+        config['confluence_publish_root'] = '3242342342334'
+
+        out_dir = self.build(self.dataset, config=config)
+        with parse('index', out_dir) as data:
+            page_refs = data.find_all('ri:page')
+            assert len(page_refs) == 2
+            self.assertEqual(page_refs[0]['ri:content-title'], 'readme -9e1a9212d2')
+            self.assertEqual(page_refs[1]['ri:content-title'], 'readme -51b1dbc890')


### PR DESCRIPTION
Adding an option to confluence_publish_postfix for making it dynamic  and thus allowing users to be able to publish pages with the same titles in sub directories